### PR TITLE
Implement @secrets, with AWS support

### DIFF
--- a/metaflow/extension_support/plugins.py
+++ b/metaflow/extension_support/plugins.py
@@ -178,6 +178,7 @@ _plugin_categories = {
     "environment": lambda x: x.TYPE,
     "metadata_provider": lambda x: x.TYPE,
     "datastore": lambda x: x.TYPE,
+    "secrets_provider": lambda x: x.TYPE,
     "sidecar": None,
     "logging_sidecar": None,
     "monitor_sidecar": None,

--- a/metaflow/metaflow_config.py
+++ b/metaflow/metaflow_config.py
@@ -29,6 +29,7 @@ DEFAULT_METADATA = from_conf("DEFAULT_METADATA", "local")
 DEFAULT_MONITOR = from_conf("DEFAULT_MONITOR", "nullSidecarMonitor")
 DEFAULT_PACKAGE_SUFFIXES = from_conf("DEFAULT_PACKAGE_SUFFIXES", ".py,.R,.RDS")
 DEFAULT_AWS_CLIENT_PROVIDER = from_conf("DEFAULT_AWS_CLIENT_PROVIDER", "boto3")
+DEFAULT_SECRETS_BACKEND_TYPE = from_conf("DEFAULT_SECRETS_BACKEND_TYPE")
 
 
 ###
@@ -128,6 +129,9 @@ DATATOOLS_LOCALROOT = from_conf(
     if DATASTORE_SYSROOT_LOCAL
     else None,
 )
+
+# Secrets Backend - AWS Secrets Manager configuration
+AWS_SECRETS_MANAGER_DEFAULT_REGION = from_conf("AWS_SECRETS_MANAGER_DEFAULT_REGION")
 
 # The root directory to save artifact pulls in, when using S3 or Azure
 ARTIFACT_LOCALROOT = from_conf("ARTIFACT_LOCALROOT", os.getcwd())

--- a/metaflow/plugins/__init__.py
+++ b/metaflow/plugins/__init__.py
@@ -23,6 +23,7 @@ STEP_DECORATORS_DESC = [
     ("catch", ".catch_decorator.CatchDecorator"),
     ("timeout", ".timeout_decorator.TimeoutDecorator"),
     ("environment", ".environment_decorator.EnvironmentDecorator"),
+    ("secrets", ".secrets.secrets_decorator.SecretsDecorator"),
     ("parallel", ".parallel_decorator.ParallelDecorator"),
     ("retry", ".retry_decorator.RetryDecorator"),
     ("resources", ".resources_decorator.ResourcesDecorator"),
@@ -106,6 +107,14 @@ SENSOR_FLOW_DECORATORS = [
 
 FLOW_DECORATORS_DESC += SENSOR_FLOW_DECORATORS
 
+SECRETS_PROVIDERS_DESC = [
+    ("inline", ".secrets.inline_secrets_provider.InlineSecretsProvider"),
+    (
+        "aws-secrets-manager",
+        ".aws.secrets_manager.aws_secrets_manager_secrets_provider.AwsSecretsManagerSecretsProvider",
+    ),
+]
+
 process_plugins(globals())
 
 
@@ -126,6 +135,7 @@ SIDECARS.update(LOGGING_SIDECARS)
 SIDECARS.update(MONITOR_SIDECARS)
 
 AWS_CLIENT_PROVIDERS = resolve_plugins("aws_client_provider")
+SECRETS_PROVIDERS = resolve_plugins("secrets_provider")
 
 # Cards; due to the way cards were designed, it is harder to make them fit
 # in the resolve_plugins mechanism. This should be OK because it is unlikely that

--- a/metaflow/plugins/airflow/airflow.py
+++ b/metaflow/plugins/airflow/airflow.py
@@ -27,6 +27,8 @@ from metaflow.metaflow_config import (
     AIRFLOW_KUBERNETES_KUBECONFIG_FILE,
     DATASTORE_SYSROOT_GS,
     CARD_GSROOT,
+    DEFAULT_SECRETS_BACKEND_TYPE,
+    AWS_SECRETS_MANAGER_DEFAULT_REGION,
 )
 from metaflow.parameters import DelayedEvaluationParameter, deploy_time_eval
 from metaflow.plugins.kubernetes.kubernetes import Kubernetes
@@ -389,6 +391,13 @@ class Airflow(object):
         ] = AZURE_STORAGE_BLOB_SERVICE_ENDPOINT
         env["METAFLOW_DATASTORE_SYSROOT_AZURE"] = DATASTORE_SYSROOT_AZURE
         env["METAFLOW_CARD_AZUREROOT"] = CARD_AZUREROOT
+        if DEFAULT_SECRETS_BACKEND_TYPE:
+            env["METAFLOW_DEFAULT_SECRETS_BACKEND_TYPE"] = DEFAULT_SECRETS_BACKEND_TYPE
+        if AWS_SECRETS_MANAGER_DEFAULT_REGION:
+            env[
+                "METAFLOW_AWS_SECRETS_MANAGER_DEFAULT_REGION"
+            ] = AWS_SECRETS_MANAGER_DEFAULT_REGION
+
         env.update(additional_mf_variables)
 
         service_account = (

--- a/metaflow/plugins/argo/argo_workflows.py
+++ b/metaflow/plugins/argo/argo_workflows.py
@@ -24,6 +24,8 @@ from metaflow.metaflow_config import (
     DATASTORE_SYSROOT_GS,
     CARD_AZUREROOT,
     CARD_GSROOT,
+    DEFAULT_SECRETS_BACKEND_TYPE,
+    AWS_SECRETS_MANAGER_DEFAULT_REGION,
 )
 from metaflow.mflog import BASH_SAVE_LOGS, bash_capture_logs, export_mflog_env_vars
 from metaflow.parameters import deploy_time_eval
@@ -801,6 +803,12 @@ class ArgoWorkflows(object):
 
             # support Metaflow sandboxes
             env["METAFLOW_INIT_SCRIPT"] = KUBERNETES_SANDBOX_INIT_SCRIPT
+
+            # secrets stuff
+            env["METAFLOW_DEFAULT_SECRETS_BACKEND_TYPE"] = DEFAULT_SECRETS_BACKEND_TYPE
+            env[
+                "METAFLOW_AWS_SECRETS_MANAGER_DEFAULT_REGION"
+            ] = AWS_SECRETS_MANAGER_DEFAULT_REGION
 
             # Azure stuff
             env[

--- a/metaflow/plugins/aws/batch/batch.py
+++ b/metaflow/plugins/aws/batch/batch.py
@@ -18,6 +18,8 @@ from metaflow.metaflow_config import (
     BATCH_EMIT_TAGS,
     CARD_S3ROOT,
     S3_ENDPOINT_URL,
+    DEFAULT_SECRETS_BACKEND_TYPE,
+    AWS_SECRETS_MANAGER_DEFAULT_REGION,
 )
 from metaflow.mflog import (
     export_mflog_env_vars,
@@ -236,6 +238,16 @@ class Batch(object):
             .environment_variable("METAFLOW_CARD_S3ROOT", CARD_S3ROOT)
             .environment_variable("METAFLOW_RUNTIME_ENVIRONMENT", "aws-batch")
         )
+        if DEFAULT_SECRETS_BACKEND_TYPE is not None:
+            job.environment_variable(
+                "METAFLOW_DEFAULT_SECRETS_BACKEND_TYPE", DEFAULT_SECRETS_BACKEND_TYPE
+            )
+        if AWS_SECRETS_MANAGER_DEFAULT_REGION is not None:
+            job.environment_variable(
+                "METAFLOW_AWS_SECRETS_MANAGER_DEFAULT_REGION",
+                AWS_SECRETS_MANAGER_DEFAULT_REGION,
+            )
+
         # Skip setting METAFLOW_DATASTORE_SYSROOT_LOCAL because metadata sync between the local user
         # instance and the remote AWS Batch instance assumes metadata is stored in DATASTORE_LOCAL_DIR
         # on the remote AWS Batch instance; this happens when METAFLOW_DATASTORE_SYSROOT_LOCAL

--- a/metaflow/plugins/aws/secrets_manager/aws_secrets_manager_secrets_provider.py
+++ b/metaflow/plugins/aws/secrets_manager/aws_secrets_manager_secrets_provider.py
@@ -1,0 +1,163 @@
+import base64
+import json
+from json import JSONDecodeError
+
+
+from metaflow.exception import MetaflowException
+from metaflow.metaflow_config import AWS_SECRETS_MANAGER_DEFAULT_REGION
+from metaflow.plugins.secrets import SecretsProvider
+import re
+
+
+class MetaflowAWSSecretsManagerBadResponse(MetaflowException):
+    """Raised when the response from AWS Secrets Manager is not valid in some way"""
+
+
+class MetaflowAWSSecretsManagerDuplicateKey(MetaflowException):
+    """Raised when the response from AWS Secrets Manager contains duplicate keys"""
+
+
+class MetaflowAWSSecretsManagerJSONParseError(MetaflowException):
+    """Raised when the SecretString response from AWS Secrets Manager is not valid JSON"""
+
+
+class MetaflowAWSSecretsManagerNotJSONObject(MetaflowException):
+    """Raised when the SecretString response from AWS Secrets Manager is not valid JSON object (dictionary)"""
+
+
+def _sanitize_key_as_env_var(key):
+    """
+    Sanitize a key as an environment variable name.
+    This is purely a convenience trade-off to cover common cases well, vs. introducing
+    ambiguities (e.g. did the final '_' come from '.', or '-' or is original?).
+
+    1/27/2023(jackie):
+
+    We start with few rules and should *sparingly* add more over time.
+    Also, it's TBD whether all possible providers will share the same sanitization logic.
+    Therefore we will keep this function private for now
+    """
+    return key.replace("-", "_").replace(".", "_")
+
+
+class AwsSecretsManagerSecretsProvider(SecretsProvider):
+    TYPE = "aws-secrets-manager"
+
+    def get_secret_as_dict(self, secret_id, options={}):
+        """
+        Reads a secret from AWS Secrets Manager and returns it as a dictionary of environment variables.
+
+        The secret payload from AWS is EITHER a string OR a binary blob.
+
+        If the secret contains a string payload ("SecretString"):
+        - if the `parse_secret_string_as_json` option is True (default):
+            {SecretString} will be parsed as a JSON. If successfully parsed, AND the JSON contains a
+            top-level object, each entry K/V in the object will also be converted to an entry in the result. V will
+            always be casted to a string (if not already a string).
+        - If `parse_secret_string_as_json` option is False:
+            {SecretString} will be returned as a single entry in the result, with the key being the secret_id.
+
+        Otherwise, the secret contains a binary blob payload ("SecretBinary"). In this case
+        - The result dic contains '{SecretName}': '{SecretBinary}', where {SecretBinary} is a base64-encoded string
+
+        All keys in the result are sanitized to be more valid environment variable names. This is done on a best effort
+        basis. Further validation is expected to be done by the invoking @secrets decorator itself.
+
+        :param secret_id: ARN or friendly name of the secret
+        :param options: unused
+        :return: dict of environment variables. All keys and values are strings.
+        """
+        import botocore
+        from metaflow.plugins.aws.aws_client import get_aws_client
+
+        effective_aws_region = None
+        # arn:aws:secretsmanager:<Region>:<AccountId>:secret:SecretName-6RandomCharacters
+        m = re.match("arn:aws:secretsmanager:([^:]+):", secret_id)
+        if m:
+            effective_aws_region = m.group(1)
+        elif "region" in options:
+            effective_aws_region = options["region"]
+        else:
+            effective_aws_region = AWS_SECRETS_MANAGER_DEFAULT_REGION
+        # At the end of all that, `effective_aws_region` may still be None.
+        # This might still be OK, if there is fallback AWS region info in environment like:
+        # .aws/config or AWS_REGION env var or AWS_DEFAULT_REGION env var, etc.
+        try:
+            secrets_manager_client = get_aws_client(
+                "secretsmanager", client_params={"region_name": effective_aws_region}
+            )
+        except botocore.exceptions.NoRegionError:
+            # We try our best with a nice error message.
+            # When run in Kubernetes or Argo Workflows, the traceback is still monstrous.
+            # TODO: Find a way to show a concise error in logs
+            raise MetaflowException(
+                "Default region is not specified for AWS Secrets Manager. Please set METAFLOW_AWS_SECRETS_MANAGER_DEFAULT_REGION"
+            )
+        result = {}
+
+        def _sanitize_and_add_entry_to_result(k, v):
+            # Two jobs - sanitize, and check for dupes
+            sanitized_k = _sanitize_key_as_env_var(k)
+            if sanitized_k in result:
+                raise MetaflowAWSSecretsManagerDuplicateKey(
+                    "Duplicate key in secret: '%s' (sanitizes to '%s')"
+                    % (k, sanitized_k)
+                )
+            result[sanitized_k] = v
+
+        """
+        These are the exceptions that can be raised by the AWS SDK:
+        
+        SecretsManager.Client.exceptions.ResourceNotFoundException
+        SecretsManager.Client.exceptions.InvalidParameterException
+        SecretsManager.Client.exceptions.InvalidRequestException
+        SecretsManager.Client.exceptions.DecryptionFailure
+        SecretsManager.Client.exceptions.InternalServiceError
+        
+        Looks pretty informative already, so we won't catch here directly.
+        
+        1/27/2023(jackie) - We will evolve this over time as we learn more.
+        """
+        response = secrets_manager_client.get_secret_value(SecretId=secret_id)
+        if "Name" not in response:
+            raise MetaflowAWSSecretsManagerBadResponse(
+                "Secret 'Name' is missing in response"
+            )
+        secret_name = response["Name"]
+        if "SecretString" in response:
+            secret_str = response["SecretString"]
+            if options.get("json", True):
+                try:
+                    obj = json.loads(secret_str)
+                    if type(obj) == dict:
+                        for k, v in obj.items():
+                            # We try to make it work here - cast to string always
+                            _sanitize_and_add_entry_to_result(k, str(v))
+                    else:
+                        raise MetaflowAWSSecretsManagerNotJSONObject(
+                            "Secret string is a JSON, but not an object (dict-like) - actual type %s."
+                            % type(obj)
+                        )
+                except JSONDecodeError:
+                    raise MetaflowAWSSecretsManagerJSONParseError(
+                        "Secret string could not be parsed as JSON"
+                    )
+            else:
+                _sanitize_and_add_entry_to_result(secret_name, secret_str)
+
+        elif "SecretBinary" in response:
+            # boto3 docs say response gives base64 encoded, but it's wrong.
+            # See https://github.com/boto/boto3/issues/2735
+            # In reality, we get raw bytes.  We will encode it ourselves to become env var ready.
+            # Note env vars values may not contain null bytes.... therefore we cannot leave it as
+            # bytes.
+            #
+            # The trailing decode gives us a final UTF-8 string.
+            _sanitize_and_add_entry_to_result(
+                secret_name, base64.b64encode(response["SecretBinary"]).decode()
+            )
+        else:
+            raise MetaflowAWSSecretsManagerBadResponse(
+                "Secret response is missing both 'SecretString' and 'SecretBinary'"
+            )
+        return result

--- a/metaflow/plugins/kubernetes/kubernetes.py
+++ b/metaflow/plugins/kubernetes/kubernetes.py
@@ -21,6 +21,8 @@ from metaflow.metaflow_config import (
     CARD_AZUREROOT,
     CARD_GSROOT,
     DATASTORE_SYSROOT_GS,
+    DEFAULT_SECRETS_BACKEND_TYPE,
+    AWS_SECRETS_MANAGER_DEFAULT_REGION,
 )
 from metaflow.mflog import (
     BASH_SAVE_LOGS,
@@ -198,9 +200,16 @@ class Kubernetes(object):
             .environment_variable("METAFLOW_DEFAULT_METADATA", DEFAULT_METADATA)
             .environment_variable("METAFLOW_KUBERNETES_WORKLOAD", 1)
             .environment_variable("METAFLOW_RUNTIME_ENVIRONMENT", "kubernetes")
+            .environment_variable(
+                "METAFLOW_DEFAULT_SECRETS_BACKEND_TYPE", DEFAULT_SECRETS_BACKEND_TYPE
+            )
             .environment_variable("METAFLOW_CARD_S3ROOT", CARD_S3ROOT)
             .environment_variable(
                 "METAFLOW_DEFAULT_AWS_CLIENT_PROVIDER", DEFAULT_AWS_CLIENT_PROVIDER
+            )
+            .environment_variable(
+                "METAFLOW_AWS_SECRETS_MANAGER_DEFAULT_REGION",
+                AWS_SECRETS_MANAGER_DEFAULT_REGION,
             )
             .environment_variable("METAFLOW_S3_ENDPOINT_URL", S3_ENDPOINT_URL)
             .environment_variable(

--- a/metaflow/plugins/secrets/__init__.py
+++ b/metaflow/plugins/secrets/__init__.py
@@ -1,0 +1,11 @@
+import abc
+from typing import Dict
+
+
+class SecretsProvider(abc.ABC):
+    TYPE = None
+
+    @abc.abstractmethod
+    def get_secret_as_dict(self, secret_id, options={}) -> Dict[str, str]:
+        """Retrieve the secret from secrets backend, and return a dictionary of
+        environment variables."""

--- a/metaflow/plugins/secrets/inline_secrets_provider.py
+++ b/metaflow/plugins/secrets/inline_secrets_provider.py
@@ -1,0 +1,9 @@
+from metaflow.plugins.secrets import SecretsProvider
+
+
+class InlineSecretsProvider(SecretsProvider):
+    TYPE = "inline"
+
+    def get_secret_as_dict(self, secret_id, options={}):
+        """Intended to be used for testing purposes only."""
+        return options.get("env_vars", {})

--- a/metaflow/plugins/secrets/secrets_decorator.py
+++ b/metaflow/plugins/secrets/secrets_decorator.py
@@ -1,0 +1,239 @@
+import os
+import re
+
+from metaflow.exception import MetaflowException
+from metaflow.decorators import StepDecorator
+from metaflow.unbounded_foreach import UBF_CONTROL
+
+DISALLOWED_SECRETS_ENV_VAR_PREFIXES = ["METAFLOW_"]
+
+
+def get_default_secrets_backend_type():
+    from metaflow.metaflow_config import DEFAULT_SECRETS_BACKEND_TYPE
+
+    if DEFAULT_SECRETS_BACKEND_TYPE is None:
+        raise MetaflowException(
+            "No default secrets backend type configured, but needed by @secrets. "
+            "Set METAFLOW_DEFAULT_SECRETS_BACKEND_TYPE."
+        )
+    return DEFAULT_SECRETS_BACKEND_TYPE
+
+
+class SecretSpec:
+    def __init__(self, secrets_backend_type, secret_id, options={}):
+        self._secrets_backend_type = secrets_backend_type
+        self._secret_id = secret_id
+        self._options = options
+
+    @property
+    def secrets_backend_type(self):
+        return self._secrets_backend_type
+
+    @property
+    def secret_id(self):
+        return self._secret_id
+
+    @property
+    def options(self):
+        return self._options
+
+    def to_json(self):
+        """Mainly used for testing... not the same as the input dict in secret_spec_from_dict()!"""
+        return {
+            "secrets_backend_type": self.secrets_backend_type,
+            "secret_id": self.secret_id,
+            "options": self.options,
+        }
+
+    def __str__(self):
+        return "%s (%s)" % (self._secret_id, self._secrets_backend_type)
+
+    @staticmethod
+    def secret_spec_from_str(secret_spec_str):
+        # "." may be used in secret_id one day (provider specific). HOWEVER, it provides the best UX for
+        # non-conflicting cases (i.e. for secret ids that don't contain "."). This is true for all AWS
+        # Secrets Manager secrets.
+        #
+        # So we skew heavily optimize for best upfront UX for the present (1/2023).
+        #
+        # If/when a certain secret backend supports "." secret names, we can figure out a solution at that time.
+        # At a minimum, dictionary style secret spec may be used with no code changes (see secret_spec_from_dict()).
+        # Other options could be:
+        #  - accept and document that "." secret_ids don't work in Metaflow (across all possible providers)
+        #  - add a Metaflow config variable that specifies the separator (default ".")
+        #  - smarter spec parsing, that errors on secrets that look ambiguous. "aws-secrets-manager.XYZ" could mean:
+        #    + secret_id "XYZ" in aws-secrets-manager backend, OR
+        #    + secret_id "aws-secrets-manager.XYZ" default backend (if it is defined).
+        #    + in this case, user can simply set "azure-key-vault.aws-secrets-manager.XYZ" instead!
+        parts = secret_spec_str.split(".", maxsplit=1)
+        if len(parts) == 1:
+            secrets_backend_type = get_default_secrets_backend_type()
+            secret_id = parts[0]
+        else:
+            secrets_backend_type = parts[0]
+            secret_id = parts[1]
+        return SecretSpec(secrets_backend_type, secret_id=secret_id)
+
+    @staticmethod
+    def secret_spec_from_dict(secret_spec_dict):
+        if "type" not in secret_spec_dict:
+            secrets_backend_type = get_default_secrets_backend_type()
+        else:
+            secrets_backend_type = secret_spec_dict["type"]
+            if not isinstance(secrets_backend_type, str):
+                raise MetaflowException(
+                    "Bad @secrets specification - 'type' must be a string - found %s"
+                    % type(secrets_backend_type)
+                )
+        secret_id = secret_spec_dict.get("id")
+        if not isinstance(secret_id, str):
+            raise MetaflowException(
+                "Bad @secrets specification - 'id' must be a string - found %s"
+                % type(secret_id)
+            )
+        options = secret_spec_dict.get("options", {})
+        if not isinstance(options, dict):
+            raise MetaflowException(
+                "Bad @secrets specification - 'option' must be a dict - found %s"
+                % type(options)
+            )
+        return SecretSpec(secrets_backend_type, secret_id=secret_id, options=options)
+
+
+def validate_env_vars_across_secrets(all_secrets_env_vars):
+    vars_injected_by = {}
+    for secret_spec, env_vars in all_secrets_env_vars:
+        for k in env_vars:
+            if k in vars_injected_by:
+                raise MetaflowException(
+                    "Secret '%s' will inject '%s' as env var, and it is also added by '%s'"
+                    % (secret_spec, k, vars_injected_by[k])
+                )
+            vars_injected_by[k] = secret_spec
+
+
+def validate_env_vars_vs_existing_env(all_secrets_env_vars):
+    for secret_spec, env_vars in all_secrets_env_vars:
+        for k in env_vars:
+            if k in os.environ:
+                raise MetaflowException(
+                    "Secret '%s' will inject '%s' as env var, but it already exists in env"
+                    % (secret_spec, k)
+                )
+
+
+def validate_env_vars(env_vars):
+    for k, v in env_vars.items():
+        if not isinstance(k, str):
+            raise MetaflowException("Found non string key %s (%s)" % (str(k), type(k)))
+        if not isinstance(v, str):
+            raise MetaflowException(
+                "Found non string value %s (%s)" % (str(v), type(v))
+            )
+        if not re.fullmatch("[a-zA-Z_][a-zA-Z0-9_]*", k):
+            raise MetaflowException("Found invalid env var name '%s'." % k)
+        for disallowed_prefix in DISALLOWED_SECRETS_ENV_VAR_PREFIXES:
+            if k.startswith(disallowed_prefix):
+                raise MetaflowException(
+                    "Found disallowed env var name '%s' (starts with '%s')."
+                    % (k, disallowed_prefix)
+                )
+
+
+def get_secrets_backend_provider(secrets_backend_type):
+    from metaflow.plugins import SECRETS_PROVIDERS
+
+    try:
+        provider_cls = [
+            pc for pc in SECRETS_PROVIDERS if pc.TYPE == secrets_backend_type
+        ][0]
+        return provider_cls()
+    except IndexError:
+        raise MetaflowException(
+            "Unknown secrets backend type %s (available types: %s)"
+            % (
+                secrets_backend_type,
+                ", ".join(pc.TYPE for pc in SECRETS_PROVIDERS if pc.TYPE != "inline"),
+            )
+        )
+
+
+class SecretsDecorator(StepDecorator):
+    """
+    Specifies secrets to be retrieved and injected as environment variables prior to the execution of a step.
+
+    Parameters
+    ----------
+    sources : List[Union[str,dict]]
+        List of secret specs, defining how the secrets are to be retrieved
+    """
+
+    name = "secrets"
+    defaults = {"sources": []}
+
+    def task_pre_step(
+        self,
+        step_name,
+        task_datastore,
+        metadata,
+        run_id,
+        task_id,
+        flow,
+        graph,
+        retry_count,
+        max_user_code_retries,
+        ubf_context,
+        inputs,
+    ):
+        if ubf_context == UBF_CONTROL:
+            """control tasks (as used in "unbounded for each") don't need secrets"""
+            return
+        # List of pairs (secret_spec, env_vars_from_this_spec)
+        all_secrets_env_vars = []
+        secret_specs = []
+
+        for secret_spec_str_or_dict in self.attributes["sources"]:
+            if isinstance(secret_spec_str_or_dict, str):
+                secret_specs.append(
+                    SecretSpec.secret_spec_from_str(secret_spec_str_or_dict)
+                )
+            elif isinstance(secret_spec_str_or_dict, dict):
+                secret_specs.append(
+                    SecretSpec.secret_spec_from_dict(secret_spec_str_or_dict)
+                )
+            else:
+                raise MetaflowException(
+                    "@secrets sources items must be either a string or a dict"
+                )
+
+        for secret_spec in secret_specs:
+            secrets_backend_provider = get_secrets_backend_provider(
+                secret_spec.secrets_backend_type
+            )
+            try:
+                env_vars_for_secret = secrets_backend_provider.get_secret_as_dict(
+                    secret_spec.secret_id, options=secret_spec.options
+                )
+            except Exception as e:
+                raise MetaflowException(
+                    "Failed to retrieve secret '%s': %s" % (secret_spec.secret_id, e)
+                )
+            try:
+                validate_env_vars(env_vars_for_secret)
+            except ValueError as e:
+                raise MetaflowException(
+                    "Invalid env vars from secret %s: %s"
+                    % (secret_spec.secret_id, str(e))
+                )
+            all_secrets_env_vars.append((secret_spec, env_vars_for_secret))
+
+        validate_env_vars_across_secrets(all_secrets_env_vars)
+        validate_env_vars_vs_existing_env(all_secrets_env_vars)
+
+        # By this point
+        # all_secrets_env_vars contains a list of dictionaries... env maps.
+        # - env maps must be disjoint from each other
+        # - env maps must be disjoint from existing current process os.environ
+
+        for secrets_env_vars in all_secrets_env_vars:
+            os.environ.update(secrets_env_vars[1].items())

--- a/test/core/tests/secrets_decorator.py
+++ b/test/core/tests/secrets_decorator.py
@@ -1,0 +1,33 @@
+from metaflow_test import MetaflowTest, ExpectationFailed, steps, tag
+
+
+INLINE_SECRETS_VARS = [
+    {
+        "type": "inline",
+        "id": "1",
+        "options": {
+            "env_vars": {
+                "secret_1": "Pizza is a vegetable.",
+                "SECRET_2": "How do eels reproduce?",
+            },
+        },
+    }
+]
+
+
+class SecretsDecoratorTest(MetaflowTest):
+    """
+    Test that checks that the timeout decorator works as intended.
+    """
+
+    @tag("secrets(sources=%s)" % repr(INLINE_SECRETS_VARS))
+    @steps(1, ["all"])
+    def step_all(self):
+        import os
+        from metaflow import current
+
+        if current.task_id.startswith("control-"):
+            return
+
+        assert os.environ.get("secret_1") == "Pizza is a vegetable."
+        assert os.environ.get("SECRET_2") == "How do eels reproduce?"

--- a/test/unit/test_secrets_decorator.py
+++ b/test/unit/test_secrets_decorator.py
@@ -1,0 +1,157 @@
+import os
+import time
+import unittest
+from unittest.mock import patch
+
+from metaflow.exception import MetaflowException
+from metaflow.metaflow_config import DEFAULT_SECRETS_BACKEND_TYPE
+from metaflow.plugins.secrets.secrets_decorator import (
+    SecretSpec,
+    validate_env_vars_across_secrets,
+    validate_env_vars_vs_existing_env,
+    validate_env_vars,
+    get_secrets_backend_provider,
+)
+
+
+class TestSecretsDecorator(unittest.TestCase):
+    def test_missing_default_secrets_backend_type(self):
+        self.assertIsNone(DEFAULT_SECRETS_BACKEND_TYPE)
+        # assumes DEFAULT_SECRETS_BACKEND_TYPE is None when we run this test
+        with self.assertRaises(MetaflowException):
+            SecretSpec.secret_spec_from_str("secret_id")
+
+    @patch(
+        "metaflow.metaflow_config.DEFAULT_SECRETS_BACKEND_TYPE",
+        "some-default-backend-type",
+    )
+    def test_constructors(self):
+        # from str
+        # explicit type
+        self.assertEqual(
+            {
+                "options": {},
+                "secret_id": "the_id",
+                "secrets_backend_type": "explicit-type",
+            },
+            SecretSpec.secret_spec_from_str("explicit-type.the_id").to_json(),
+        )
+        # implicit type
+        self.assertEqual(
+            {
+                "options": {},
+                "secret_id": "the_id",
+                "secrets_backend_type": "some-default-backend-type",
+            },
+            SecretSpec.secret_spec_from_str("the_id").to_json(),
+        )
+
+        # from dict
+        # explicit type, no options
+        self.assertEqual(
+            {
+                "options": {},
+                "secret_id": "the_id",
+                "secrets_backend_type": "explicit-type",
+            },
+            SecretSpec.secret_spec_from_dict(
+                {
+                    "type": "explicit-type",
+                    "id": "the_id",
+                }
+            ).to_json(),
+        )
+        # implicit type, with options
+        self.assertEqual(
+            {
+                "options": {"a": "b"},
+                "secret_id": "the_id",
+                "secrets_backend_type": "some-default-backend-type",
+            },
+            SecretSpec.secret_spec_from_dict(
+                {"id": "the_id", "options": {"a": "b"}}
+            ).to_json(),
+        )
+
+        # check raise on bad type field
+        with self.assertRaises(MetaflowException):
+            SecretSpec.secret_spec_from_dict(
+                {
+                    "type": 42,
+                    "id": "the_id",
+                }
+            )
+        # check raise on bad id field
+        with self.assertRaises(MetaflowException):
+            SecretSpec.secret_spec_from_dict(
+                {
+                    "id": 42,
+                }
+            )
+        # check raise on bad options field
+        with self.assertRaises(MetaflowException):
+            SecretSpec.secret_spec_from_dict({"id": "the_id", "options": []})
+
+    def test_secrets_provider_resolution(self):
+        with self.assertRaises(MetaflowException):
+            get_secrets_backend_provider(str(time.time()))
+
+
+class TestEnvVarValidations(unittest.TestCase):
+    def test_validate_env_vars_across_secrets(self):
+        # overlap
+        all_secrets_env_vars = [
+            (SecretSpec.secret_spec_from_str("t.1"), {"A": "a", "B": "b"}),
+            (SecretSpec.secret_spec_from_str("t.2"), {"B": "b", "C": "c"}),
+        ]
+        with self.assertRaises(MetaflowException):
+            validate_env_vars_across_secrets(all_secrets_env_vars)
+
+    def test_validate_env_vars_vs_existing_env(self):
+        # assumes there is at least one existing env var - quite reasonable
+        existing_os_env_k, existing_os_env_v = next(iter(os.environ.items()))
+        all_secrets_env_vars = [
+            (
+                SecretSpec.secret_spec_from_str("t.1"),
+                {"A": "a", existing_os_env_k: existing_os_env_v},
+            ),
+        ]
+        with self.assertRaises(MetaflowException):
+            validate_env_vars_vs_existing_env(all_secrets_env_vars)
+
+    def test_validate_env_vars(self):
+        # happy path
+        env_vars = {
+            "TYPICAL_KEY_1": "TYPICAL_VALUE_1",
+            "_typical_key_2": "typical_value_2",
+        }
+        validate_env_vars(env_vars)
+
+        # keys with wrong type
+        mistyped_keys = [1, tuple(), b"old_school"]
+        for k in mistyped_keys:
+            with self.assertRaises(MetaflowException):
+                validate_env_vars({k: "v"})
+
+        # values with wrong type
+        mistyped_values = [1, {}, b"old_school"]
+        for i, v in enumerate(mistyped_values):
+            with self.assertRaises(MetaflowException):
+                validate_env_vars({f"K{i}": v})
+
+        # weird keys
+        weird_keys = [
+            "1_",
+            "hello world",
+            "hey_arnold!",
+            "I_\u2665_NY",
+            "door-",
+            "METAFLOW_SOMETHING_OR_OTHER",
+        ]
+        for k in weird_keys:
+            with self.assertRaises(MetaflowException):
+                validate_env_vars({k: "v"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Recreated from original PR: https://github.com/Netflix/metaflow/pull/1251

RFC doc: https://docs.google.com/document/d/1vhU7lLZo1znF6of_cE8KewNae99_fUBsaoFHhW8FJew/edit#heading=h.tt3aazlsd22b 

This PR implements the general @secrets decorator interface, as well as AWS Secrets Manager backend.

How to use `@secrets(sources=[...])`?  `sources` is a list of strings or dictionaries.

String-style will cover most users with vanilla requirements (secret payload are JSON objects, to be unrolled as env vars).

Dictionary-style will allow specification of provider spec...